### PR TITLE
make generating powers enforce internal structure

### DIFF
--- a/src/circuit/num.rs
+++ b/src/circuit/num.rs
@@ -363,6 +363,22 @@ impl<E: Engine> AllocatedNum<E> {
         Ok(())
     }
 
+    pub fn assert_number<CS>(
+        &self,
+        mut cs: CS,
+        number: &E::Fr
+    ) -> Result<(), SynthesisError>
+        where CS: ConstraintSystem<E>
+    {
+        cs.enforce(
+            || "number assertion constraint",
+            |lc| lc + self.variable - (number.clone(), CS::one()),
+            |lc| lc + CS::one(),
+            |lc| lc
+        );
+
+        Ok(())
+    }
     /// Takes two allocated numbers (a, b) and returns
     /// (b, a) if the condition is true, and (a, b)
     /// otherwise.

--- a/src/circuit/polynomial_lookup.rs
+++ b/src/circuit/polynomial_lookup.rs
@@ -18,21 +18,12 @@ pub fn generate_powers<E: Engine, CS>(
                 return Ok(E::Fr::one());
             }
         )?;
-
+        power.assert_number(cs.namespace(||"0-th power equals 1"), &E::Fr::one())?;
         result.push(power.clone());
 
         for i in 1..max_power {
-            power = num::AllocatedNum::alloc(
-                cs.namespace(|| format!("{}-th power", i)), 
-                || {
-                    let mut power = power.get_value().get()?.clone();
-                    let value = base.get_value().get()?.clone();
-                    power.mul_assign(&value);
-                    
-                    Ok(power)
-                }
-            )?;
-
+            power = power.mul(cs.namespace(||format!("{}-th power", i)), base)?;
+           
             result.push(power.clone());
         }
 


### PR DESCRIPTION
Generating powers from poly_lookup module is more suitable if it enforces its own structure internally