### PR TITLE
Changed rust-crypto to rust-crypto-wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "franklin-crypto"
 version = "0.0.5"
 
 [lib]
-crate-type = ["lib", "staticlib"]
+crate-type = ["cdylib", "lib", "staticlib"]
 
 [features]
 default = ["multicore"]
@@ -22,7 +22,8 @@ byteorder = "1"
 serde = "1.0.80"
 serde_derive = "1.0.80"
 tiny-keccak = "1.4.2"
-rust-crypto = "0.2"
+rust-crypto-wasm = "0.3.1"
+wasm-bindgen = "0.2"
 bit-vec = "0.6"
 
 #bellman_ce = { path = "../bellman"}


### PR DESCRIPTION
franklin-crypto depends on rust-crypto, which in turn depends on rust-serialize, which is [deprecated](https://users.rust-lang.org/t/deprecation-of-rustc-serialize/10485), and can't be compiled into wasm. There is a [pull request](https://github.com/DaGenix/rust-crypto/pull/415) in rust-crypto which removes the dependency, but since no one maintains the project for years, it doesn't get merged. This is the fork from which the pull request was created: https://github.com/buttercup/rust-crypto-wasm. I changed our dependency to it.
